### PR TITLE
Fix the aspect of the exported image

### DIFF
--- a/components/tool/world-map/component.jsx
+++ b/components/tool/world-map/component.jsx
@@ -87,28 +87,37 @@ class WorldMap extends React.PureComponent {
   renderGeographies = (geographies, projection) => {
     const { flows, originGeoId, destination } = this.state;
 
-    return geographies.map(
-      geography =>
-        geography.properties.iso2 !== 'AQ' && (
-          <Geography
-            key={geography.properties.cartodb_id}
-            className={cx(
-              'world-map-geography',
-              {
-                '-destination': WorldMap.isDestinationCountry(
-                  geography.properties.iso2,
-                  flows.filter(f => !destination || f.geoId === destination)
-                ),
-              },
-              { '-origin': originGeoId === geography.properties.iso2 }
-            )}
-            geography={geography}
-            projection={projection}
-            onMouseMove={this.onMouseMove}
-            onMouseLeave={this.onMouseLeave}
-          />
+    return geographies.map(geography => {
+      if (geography.properties.iso2 === 'AQ') {
+        return;
+      }
+
+      let fillColor = '#dedede';
+      if (originGeoId === geography.properties.iso2) {
+        fillColor = '#f1ba30';
+      } else if (
+        WorldMap.isDestinationCountry(
+          geography.properties.iso2,
+          flows.filter(f => !destination || f.geoId === destination)
         )
-    );
+      ) {
+        fillColor = '#03755e';
+      }
+
+      return (
+        <Geography
+          key={geography.properties.cartodb_id}
+          className="world-map-geography"
+          fill={fillColor}
+          stroke="#ffffff"
+          strokeWidth="0.2px"
+          geography={geography}
+          projection={projection}
+          onMouseMove={this.onMouseMove}
+          onMouseLeave={this.onMouseLeave}
+        />
+      );
+    });
   };
 
   renderLines = () => {
@@ -116,24 +125,37 @@ class WorldMap extends React.PureComponent {
 
     return flows
       .filter(f => !destination || f.geoId === destination)
-      .map(flow => (
-        <Line
-          key={flow.geoId}
-          className="world-map-arc"
-          {...flow}
-          line={{
-            coordinates: {
-              start: originCoordinates,
-              end: flow.coordinates,
-            },
-            curveStyle: flow.curveStyle,
-          }}
-          buildPath={WorldMap.buildCurves}
-          strokeWidth={flow.strokeWidth}
-          onMouseMove={this.onMouseMove}
-          onMouseLeave={this.onMouseLeave}
-        />
-      ));
+      .map(flow => {
+        const style = {
+          fill: 'none',
+          stroke: 'rgba(0, 0, 0, 0.7)',
+          strokeLinecap: 'round',
+          strokeWidth: flow.strokeWidth,
+        };
+
+        return (
+          <Line
+            key={flow.geoId}
+            className="world-map-arc"
+            {...flow}
+            line={{
+              coordinates: {
+                start: originCoordinates,
+                end: flow.coordinates,
+              },
+              curveStyle: flow.curveStyle,
+            }}
+            style={{
+              default: style,
+              hover: style,
+              pressed: style,
+            }}
+            buildPath={WorldMap.buildCurves}
+            onMouseMove={this.onMouseMove}
+            onMouseLeave={this.onMouseLeave}
+          />
+        );
+      });
   };
 
   render() {

--- a/components/tool/world-map/style.scss
+++ b/components/tool/world-map/style.scss
@@ -1,64 +1,22 @@
 @import 'css/settings';
 
-/* COLORS */
-$white: #fff;
-$slate: #555;
-$warm-grey: #999;
-$origin-yellow: #F1BA30;
-$destination-green: #03755E;
-$dark-grey: rgba(0, 0, 0, 0.7); // flows
-$others-grey: #DEDEDE;
-
 .c-world-map {
   background-color: transparent;
   -webkit-tap-highlight-color: transparent;
 
   .world-map-geography {
-    fill: $others-grey;
-    stroke: $white;
-    stroke-width: 0.2px;
     outline: 0;
     pointer-events: visibleFill;
-
-    &.-destination {
-      fill: $destination-green;
-    }
-
-    &.-origin {
-      fill: $origin-yellow;
-    }
   }
 
   .world-map-arc {
-    fill: transparent;
-    stroke:  $dark-grey;
-    stroke-linecap: round;
     outline: 0;
     pointer-events: visibleStroke;
-  }
-
-  .world-map-annotation-text {
-    fill: $warm-grey;
-    font-family: $font-family-1;
-    font-size: 13px;
-    text-transform: uppercase;
-    text-align: right;
-    line-height: 0.64;
-    letter-spacing: -0.7px;
-    pointer-events: none;
-
-    + path {
-      stroke: $warm-grey;
-    }
-
-    &.-label {
-      transform: translateY(3px);
-    }
   }
 }
 
 .c-world-map-tooltip {
-  background-color: $slate;
+  background-color: $background-color-1;
   padding: rem(10px) rem(15px);
   display: flex;
   flex-direction: column;

--- a/css/_settings.scss
+++ b/css/_settings.scss
@@ -18,6 +18,8 @@ $theme-colors: (
 
 $border-color-1: rgba($text-color-1, 0.3);
 
+$background-color-1: #555;
+
 // Body
 
 $body-bg: $white;


### PR DESCRIPTION
This PR fixes the aspect of the exported image by applying the styles to the SVG features directly instead of relying on the external stylesheet.

<p align="center">
<img src="https://user-images.githubusercontent.com/6073968/87674722-4c615a80-c76e-11ea-8608-32b92e20b04c.png" alt="Exported image corresponding to beef flows coming out of Brazil" />
</p>

## Testing instructions

1. Open the app
2. Export the map

The exported image should correctly display the lines and the colours.

## Pivotal Tracker

Not tracked.
