### PR TITLE
Remove the underline of thre trase link text when not hovered

### DIFF
--- a/components/tool/trase-link/style.scss
+++ b/components/tool/trase-link/style.scss
@@ -12,7 +12,6 @@
       color: #444242;
       font-size: $font-size-m;
       font-weight: 600;
-      text-decoration-line: underline;
       text-decoration-color: rgba(black, 0.2);
     }
   }


### PR DESCRIPTION
This PR removes the underline of the Trase link text when not hovered as requested by design


