### PR TITLE
Adaptation for the legacy API shim

### DIFF
--- a/components/tool/component.js
+++ b/components/tool/component.js
@@ -121,7 +121,9 @@ const Tool = ({
           columns.countries,
           year,
           region,
-          exporter
+          exporter,
+          columns.regions,
+          columns.exporters
         );
         updateFlows(flows);
         updateFlowsLoading(false);

--- a/components/tool/trase-link/component.jsx
+++ b/components/tool/trase-link/component.jsx
@@ -5,8 +5,9 @@ import './style.scss';
 
 const TraseLink = ({ country, commodity, unit, year }) => {
   const href = useMemo(() => {
-    const traseAppUpl = TRASE_API.split('/api')[0];
-    return `${traseAppUpl}/flows/data-view?toolLayout=1&countries=${country}&commodities=${commodity}&selectedYears=${year}&selectedYears=${year}&selectedResizeBy=${unit}`;
+    const newTraseSiteURL = 'https://trase.earth';
+    // https://trase.earth/explore/supply-chain/brazil/soy?year=2004&indicator=volume
+    return `${newTraseSiteURL}/explore/supply-chain/${country}/${commodity}?year=${year}&indicator=${unit}`;
   }, [commodity, country, unit, year]);
 
   return (

--- a/modules/tool/world-map/trase-api.js
+++ b/modules/tool/world-map/trase-api.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-export const TRASE_API = 'https://us-west1-trase-mongabay-shim.cloudfunctions.net/trase-api-prod';
+export const TRASE_API = 'https://europe-west1-trase-mongabay-shim.cloudfunctions.net/trase-api-prod';
 
 export const fetchTraseContexts = () =>
   axios.get(`${TRASE_API}-contexts`).then(({ data }) => data?.data ?? []);

--- a/modules/tool/world-map/trase-api.js
+++ b/modules/tool/world-map/trase-api.js
@@ -1,21 +1,21 @@
 import axios from 'axios';
 
-export const TRASE_API = 'https://mongabay.trase.earth/api/v3';
+export const TRASE_API = 'https://us-west1-trase-mongabay-shim.cloudfunctions.net/trase-api-prod';
 
 export const fetchTraseContexts = () =>
-  axios.get(`${TRASE_API}/contexts`).then(({ data }) => data?.data ?? []);
+  axios.get(`${TRASE_API}-contexts`).then(({ data }) => data?.data ?? []);
 
 export const fetchTraseColumns = contextId =>
-  axios.get(`${TRASE_API}/columns/?context_id=${contextId}`).then(({ data }) => data?.data ?? []);
+  axios.get(`${TRASE_API}-columns/?context_id=${contextId}`).then(({ data }) => data?.data ?? []);
 
 export const fetchTraseRegions = (contextId, columnId) =>
   axios
-    .get(`${TRASE_API}/nodes/?context_id=${contextId}&node_types_ids=${columnId}`)
+    .get(`${TRASE_API}-nodes/?context_id=${contextId}&node_types_ids=${columnId}`)
     .then(({ data }) => data?.data ?? []);
 
 export const fetchTraseExporters = (contextId, columnId) =>
   axios
-    .get(`${TRASE_API}/nodes/?context_id=${contextId}&node_types_ids=${columnId}`)
+    .get(`${TRASE_API}-nodes/?context_id=${contextId}&node_types_ids=${columnId}`)
     .then(({ data }) => data?.data ?? []);
 
 export const fetchTraseFlows = (
@@ -31,11 +31,11 @@ export const fetchTraseFlows = (
 ) =>
   axios
     .get(
-      `${TRASE_API}/top-nodes/?country_id=${countryId}&commodity_id=${commodityId}&cont_attribute_id=${unitId}&node_type_id=${countryColumnId}&start_year=${year}&sources_ids=${regionId}&exporters_ids=${exporterId}&source_node_type_id=${regionColumnId}&exporter_node_type_id=${exporterColumnId}&top_n=10`
+      `${TRASE_API}-top-nodes/?country_id=${countryId}&commodity_id=${commodityId}&cont_attribute_id=${unitId}&node_type_id=${countryColumnId}&start_year=${year}&sources_ids=${regionId}&exporters_ids=${exporterId}&source_node_type_id=${regionColumnId}&exporter_node_type_id=${exporterColumnId}&top_n=10`
     )
     .then(({ data }) => data?.data.slice(0, 10) ?? []);
 
 export const fetchTraseDestinationCountries = (contextId, columnId) =>
   axios
-    .get(`${TRASE_API}/nodes/?context_id=${contextId}&node_types_ids=${columnId}`)
+    .get(`${TRASE_API}-nodes/?context_id=${contextId}&node_types_ids=${columnId}`)
     .then(({ data }) => data?.data ?? []);

--- a/modules/tool/world-map/trase-api.js
+++ b/modules/tool/world-map/trase-api.js
@@ -6,16 +6,16 @@ export const fetchTraseContexts = () =>
   axios.get(`${TRASE_API}/contexts`).then(({ data }) => data?.data ?? []);
 
 export const fetchTraseColumns = contextId =>
-  axios.get(`${TRASE_API}/contexts/${contextId}/columns`).then(({ data }) => data?.data ?? []);
+  axios.get(`${TRASE_API}/columns/?context_id=${contextId}`).then(({ data }) => data?.data ?? []);
 
 export const fetchTraseRegions = (contextId, columnId) =>
   axios
-    .get(`${TRASE_API}/contexts/${contextId}/nodes?node_types_ids=${columnId}`)
+    .get(`${TRASE_API}/nodes/?context_id=${contextId}&node_types_ids=${columnId}`)
     .then(({ data }) => data?.data ?? []);
 
 export const fetchTraseExporters = (contextId, columnId) =>
   axios
-    .get(`${TRASE_API}/contexts/${contextId}/nodes?node_types_ids=${columnId}`)
+    .get(`${TRASE_API}/nodes/?context_id=${contextId}&node_types_ids=${columnId}`)
     .then(({ data }) => data?.data ?? []);
 
 export const fetchTraseFlows = (
@@ -25,15 +25,17 @@ export const fetchTraseFlows = (
   countryColumnId,
   year,
   regionId,
-  exporterId
+  exporterId,
+  regionColumnId,
+  exporterColumnId
 ) =>
   axios
     .get(
-      `${TRASE_API}/dashboards/charts/single_year_no_ncont_node_type_view?country_id=${countryId}&commodity_id=${commodityId}&cont_attribute_id=${unitId}&node_type_id=${countryColumnId}&start_year=${year}&sources_ids=${regionId}&exporters_ids=${exporterId}&top_n=10`
+      `${TRASE_API}/top-nodes/?country_id=${countryId}&commodity_id=${commodityId}&cont_attribute_id=${unitId}&node_type_id=${countryColumnId}&start_year=${year}&sources_ids=${regionId}&exporters_ids=${exporterId}&source_node_type_id=${regionColumnId}&exporter_node_type_id=${exporterColumnId}&top_n=10`
     )
     .then(({ data }) => data?.data.slice(0, 10) ?? []);
 
 export const fetchTraseDestinationCountries = (contextId, columnId) =>
   axios
-    .get(`${TRASE_API}/contexts/${contextId}/nodes?node_types_ids=${columnId}`)
+    .get(`${TRASE_API}/nodes/?context_id=${contextId}&node_types_ids=${columnId}`)
     .then(({ data }) => data?.data ?? []);


### PR DESCRIPTION
## Adaptation for the legacy API shim

---

Changes required for compatibility with the Trase API shim https://github.com/Vizzuality/trase-api-shim:
- identifiers of countries, commodities, attributes and node types are no longer numeric - they are now strings
- the hardcoded node type names which we use to pick the node types to show on the map and in the filter drop downs had to be changed to match. Unfortunately, it is still the case that different node types are available in different country / commodity pairs
- for the endpoint that gets the top nodes for the map, I made it pass additional parameters for the region / exporter filters - the respective node type ids, because otherwise we'd end up with a complicated query 
- the link that goes back to Trase needed to be amended

### Testing instructions

To be tested locally

### Asana
https://app.asana.com/0/0/1206397948842511/f
